### PR TITLE
Remove cached image to reduce memory consumption by ~45%

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,6 @@ pub struct CosmicBgLayer {
     first_configure: bool,
     width: u32,
     height: u32,
-    last_draw: Option<u64>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -313,7 +312,6 @@ impl CosmicBg {
             height,
             first_configure: false,
             pool: None,
-            last_draw: None,
         }
     }
 }


### PR DESCRIPTION
It doesn't seem to be necessary to cache the decompressed images for each wallpaper since they are accessed infrequently. This reduced memory consumption of the process by ~45% on my system.