### PR TITLE
Derive `PartialOrd` for `Color`

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -98,14 +98,14 @@ pub struct Entry {
 }
 
 /// A background image which is colored.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
 pub enum Color {
     Single([f32; 3]),
     Gradient(Gradient),
 }
 
 /// A background image which is colored by a gradient.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
 pub struct Gradient {
     pub colors: Cow<'static, [[f32; 3]]>,
     pub radius: f32,


### PR DESCRIPTION
`PartialOrd` makes it easier to use certain algorithms such as binary search.

Related to a [PR on cosmic-settings](https://github.com/pop-os/cosmic-settings/pull/380).