### PR TITLE
fix: use appropriate libcosmic patch URL for cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic?branch=master?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
+source = "git+https://github.com/pop-os//libcosmic?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
 dependencies = [
  "atomicwrites",
  "calloop",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic?branch=master?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
+source = "git+https://github.com/pop-os//libcosmic?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -691,7 +691,7 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic?branch=master?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
+source = "git+https://github.com/pop-os//libcosmic?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
 dependencies = [
  "bitflags 2.6.0",
  "dnd",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic?branch=master?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
+source = "git+https://github.com/pop-os//libcosmic?rev=8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb#8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb"
 dependencies = [
  "futures",
  "iced_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ opt-level = 3
 
 # TODO: Remove when sctk is updated to latest calloop, like cosmic-config
 [patch.'https://github.com/pop-os/libcosmic']
-cosmic-config = { git = "https://github.com/pop-os/libcosmic?branch=master", rev = "8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb" }
+cosmic-config = { git = "https://github.com/pop-os//libcosmic", rev = "8c6f2c9ebc5c2c04fe168c2d941f8c5a416b33bb" }


### PR DESCRIPTION
See <https://github.com/pop-os/cosmic-bg/commit/ed9ea6cc15638b08c848fda042ec2df3ff69865f#r145966372> (cc @mmstick)

This fixes Cargo recording valid URLs in the lockfile and correctly finding the dependency when using `cargo vendor` (otherwise `cargo build --offline` will not work with vendored sources)

It uses a URL that follows the Cargo.toml specification, but still works around <https://github.com/rust-lang/cargo/issues/10756>

Other COSMIC projects are already using this workaround:

https://github.com/pop-os/cosmic-settings/blob/a46587fb6e945b9e213a337bbe3df14acacccae5/Cargo.toml#L53-L54
https://github.com/pop-os/xdg-shell-wrapper/blob/b5480042615ecfcf30262d5a40625e8f430b474a/Cargo.toml#L44-L48
https://github.com/pop-os/cosmic-comp/blob/536484e9dae289cc5590d35e18096ba24e7d0f1f/Cargo.toml#L118-L119