### PR TITLE
fix: set M_MMAP_THRESHOLD to prevent memory fragmentation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,32 @@ mod img_source;
 mod scaler;
 mod wallpaper;
 
+/// Access glibc malloc tunables.
+#[cfg(target_env = "gnu")]
+mod malloc {
+    use std::os::raw::c_int;
+    const M_MMAP_THRESHOLD: c_int = -3;
+
+    extern "C" {
+        fn malloc_trim(pad: usize);
+        fn mallopt(param: c_int, value: c_int) -> c_int;
+    }
+
+    /// Prevents glibc from hoarding memory via memory fragmentation.
+    pub fn limit_mmap_threshold() {
+        unsafe {
+            mallopt(M_MMAP_THRESHOLD, 65536);
+        }
+    }
+
+    /// Asks glibc to trim malloc arenas.
+    pub fn trim() {
+        unsafe {
+            malloc_trim(0);
+        }
+    }
+}
+
 use cosmic_bg_config::{state::State, Config};
 use cosmic_config::{calloop::ConfigWatchSource, CosmicConfigEntry};
 use eyre::Context;
@@ -43,19 +69,10 @@ use sctk::{
     },
     shm::{slot::SlotPool, Shm, ShmHandler},
 };
-use std::os::raw::c_int;
+
 use tracing::error;
 use tracing_subscriber::prelude::*;
 use wallpaper::Wallpaper;
-
-#[cfg(target_env = "gnu")]
-const M_MMAP_THRESHOLD: c_int = -3;
-
-#[cfg(target_env = "gnu")]
-extern "C" {
-    fn malloc_trim(pad: usize);
-    fn mallopt(param: c_int, value: c_int) -> c_int;
-}
 
 #[derive(Debug)]
 pub struct CosmicBgLayer {
@@ -73,9 +90,7 @@ pub struct CosmicBgLayer {
 fn main() -> color_eyre::Result<()> {
     // Prevents glibc from hoarding memory via memory fragmentation.
     #[cfg(target_env = "gnu")]
-    unsafe {
-        mallopt(M_MMAP_THRESHOLD, 65536);
-    }
+    malloc::limit_mmap_threshold();
 
     color_eyre::install()?;
 
@@ -162,9 +177,7 @@ fn main() -> color_eyre::Result<()> {
                         state.apply_backgrounds();
 
                         #[cfg(target_env = "gnu")]
-                        unsafe {
-                            malloc_trim(0);
-                        }
+                        malloc::trim();
 
                         tracing::debug!(
                             same_on_all = state.config.same_on_all,


### PR DESCRIPTION
I read some articles about how a default behavior of glibc malloc causes some applications to consume large amounts of RAM until reaching OOM. There's a tunable parameter called `M_MMAP_THRESHOLD` (or the `MALLOC_MMAP_THRESHOLD_` environment variable) which defines when an allocation will use mmap instead of sbrk.

Small sbrk buffers are stored by malloc in arenas for reuse by the application. mmap buffers are released by the OS instantly on drop. The problem is that the default behavior of malloc is to dynamically increase the threshold if this tunable is not set, which leads to some applications storing lots of randomly-sized gigantic buffers in its arenas, which may never be freed.

This lowered memory usage of cosmic-bg on my system from 96 MB to 25 MB.