### PR TITLE
fix: use valid license identifiers

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only
+// SPDX-License-Identifier: MPL-2.0
 
 pub mod state;
 

--- a/src/colored.rs
+++ b/src/colored.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only
+// SPDX-License-Identifier: MPL-2.0
 
 use colorgrad::Color;
 use cosmic_bg_config::Gradient;

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only'
+// SPDX-License-Identifier: MPL-2.0
 
 use crate::{CosmicBg, CosmicBgLayer};
 use image::{DynamicImage, GenericImageView};

--- a/src/img_source.rs
+++ b/src/img_source.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only
+// SPDX-License-Identifier: MPL-2.0
 
 use notify::event::{ModifyKind, RenameMode};
 use sctk::reexports::calloop::{channel, LoopHandle};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only
+// SPDX-License-Identifier: MPL-2.0
 
 mod colored;
 mod draw;

--- a/src/scaler.rs
+++ b/src/scaler.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only
+// SPDX-License-Identifier: MPL-2.0
 
 //! Background scaling methods such as fit, stretch, and zoom.
 

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0-only
+// SPDX-License-Identifier: MPL-2.0
 
 use crate::{CosmicBg, CosmicBgLayer};
 


### PR DESCRIPTION
`MPL-2.0-only` is not an existing SPDX license identifier