### PR TITLE
Match against directories in $XDG_DATA_DIRS to check for backgrounds

### DIFF
--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -230,6 +230,13 @@ impl Wallpaper {
 
     pub fn load_images(&mut self) {
         let mut image_queue = VecDeque::new();
+        let xdg_data_dirs: Vec<String> = match std::env::var("XDG_DATA_DIRS") {
+            Ok(raw_xdg_data_dirs) => raw_xdg_data_dirs
+                .split(':')
+                .map(|s| format!("{}/backgrounds/", s))
+                .collect(),
+            Err(_) => Vec::new(),
+        };
 
         match self.entry.source {
             Source::Path(ref source) => {
@@ -237,7 +244,10 @@ impl Wallpaper {
 
                 if let Ok(source) = source.canonicalize() {
                     if source.is_dir() {
-                        if source.starts_with("/usr/share/backgrounds/") {
+                        if xdg_data_dirs
+                            .iter()
+                            .any(|xdg_data_dir| source.starts_with(xdg_data_dir))
+                        {
                             // Store paths of wallpapers to be used for the slideshow.
                             for img_path in WalkDir::new(source)
                                 .follow_links(true)


### PR DESCRIPTION
At the moment, we check if a `source` is located under `/usr/share/backgrounds/` and only then do we recurse into it for more potential background images.

The `/usr/share` directory doesn't exist on _all_ Linux distributions. On NixOS, the `/usr` directory doesn't exist. What one would usually find in `/usr/share` is found in `/run/current-system/sw/share` in NixOS.

But, the paths `/usr/share` and `/run/current-system/sw/share` are included in the environment variable $XDG_DATA_DIRS. This approach of using the value of $XDG_DATA_DIRS is beneficial for two reasons:

1. We avoid hard-coding distribution-specific paths like `/run/current-system/sw`.
2. Properly initializing the $XDG_DATA_DIRS variable is the distribution's responsibility. Not setting it up correctly with system's data directories **should never happen**.