### PR TITLE
fix: handle display rotation in wallpaper rendering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,31 @@ pub struct CosmicBgLayer {
     needs_redraw: bool,
     size: Option<(u32, u32)>,
     fractional_scale: Option<u32>,
+    transform: wl_output::Transform,
+}
+
+/// Returns `true` if the given transform represents a 90° or 270° rotation.
+fn is_rotated_90_or_270(transform: wl_output::Transform) -> bool {
+    matches!(
+        transform,
+        wl_output::Transform::_90
+            | wl_output::Transform::_270
+            | wl_output::Transform::Flipped90
+            | wl_output::Transform::Flipped270
+    )
+}
+
+impl CosmicBgLayer {
+    /// Returns the effective size, swapping width and height for 90°/270° rotations.
+    pub fn effective_size(&self) -> Option<(u32, u32)> {
+        self.size.map(|(w, h)| {
+            if is_rotated_90_or_270(self.transform) {
+                (h, w)
+            } else {
+                (w, h)
+            }
+        })
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -356,6 +381,7 @@ impl CosmicBg {
             layer,
             viewport,
             wl_output: output,
+            transform: output_info.transform,
             output_info,
             size: None,
             fractional_scale,
@@ -401,10 +427,28 @@ impl CompositorHandler for CosmicBg {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _surface: &wl_surface::WlSurface,
-        _new_transform: wl_output::Transform,
+        surface: &wl_surface::WlSurface,
+        new_transform: wl_output::Transform,
     ) {
-        // TODO
+        for wallpaper in &mut self.wallpapers {
+            if let Some(layer) = wallpaper
+                .layers
+                .iter_mut()
+                .find(|layer| layer.layer.wl_surface() == surface)
+            {
+                if layer.transform != new_transform {
+                    tracing::debug!(
+                        old_transform = ?layer.transform,
+                        new_transform = ?new_transform,
+                        "output transform changed"
+                    );
+                    layer.transform = new_transform;
+                    layer.needs_redraw = true;
+                    wallpaper.draw();
+                }
+                break;
+            }
+        }
     }
 
     fn surface_enter(

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -109,7 +109,7 @@ impl Wallpaper {
                 continue;
             };
 
-            let Some((width, height)) = layer.size else {
+            let Some((width, height)) = layer.effective_size() else {
                 continue;
             };
 


### PR DESCRIPTION
## Summary

- Implement the `transform_changed` handler (previously a `// TODO` stub) to properly track output transform changes
- When a display is rotated 90° or 270°, swap wallpaper width/height so images are scaled to the correct orientation
- Add `effective_size()` method to `CosmicBgLayer` that accounts for rotation transforms

## Problem

On displays with 90°/270° rotation (including flipped variants), wallpapers are rendered with the wrong aspect ratio because the raw layer size is used without accounting for the output transform. The `transform_changed` handler was left as a TODO stub.

## Changes

**`src/main.rs`:**
- Add `transform` field to `CosmicBgLayer` struct, initialized from `output_info.transform`
- Add `is_rotated_90_or_270()` helper for detecting rotated transforms
- Add `CosmicBgLayer::effective_size()` that swaps width/height when rotated
- Implement `transform_changed()` to update the stored transform and trigger a redraw

**`src/wallpaper.rs`:**
- Use `layer.effective_size()` instead of `layer.size` in the draw path

## Test plan

- [ ] Set a display to normal orientation — wallpaper renders correctly
- [ ] Rotate a display to 90° — wallpaper dimensions swap and render correctly
- [ ] Rotate a display to 270° — wallpaper dimensions swap and render correctly
- [ ] Test with flipped rotations (Flipped90, Flipped270)
- [ ] Runtime rotation change triggers redraw with correct dimensions
- [ ] Non-rotated displays (0°, 180°, Flipped, Flipped180) are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)