### PR TITLE
Apply Exif orientation when decoding a wallpaper

### DIFF
--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -4,13 +4,14 @@ use crate::{CosmicBg, CosmicBgLayer};
 
 use std::collections::VecDeque;
 use std::fs;
+use std::io::BufReader;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use cosmic_bg_config::state::State;
 use cosmic_bg_config::{Color, Entry, SamplingMethod, ScalingMode, Source};
 use cosmic_config::CosmicConfigEntry;
-use image::{DynamicImage, ImageReader, Limits};
+use image::{DynamicImage, ImageDecoder, ImageReader, ImageResult, Limits};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use rand::rng;
 use rand::seq::SliceRandom;
@@ -126,23 +127,17 @@ impl Wallpaper {
                                 .ok()
                                 .and_then(|f| f.with_guessed_format().ok())
                             {
-                                Some(mut f) => {
-                                    let mut limits = Limits::default();
-                                    limits.max_alloc = Some(1024 * 1024 * 1024);
-                                    f.limits(limits);
-
-                                    match f.decode() {
-                                        Ok(img) => Some(img),
-                                        Err(why) => {
-                                            tracing::warn!(
-                                                ?why,
-                                                "Failed to decode image: {}",
-                                                path.display()
-                                            );
-                                            continue;
-                                        }
+                                Some(f) => match decode(f) {
+                                    Ok(img) => Some(img),
+                                    Err(why) => {
+                                        tracing::warn!(
+                                            ?why,
+                                            "Failed to decode image: {}",
+                                            path.display()
+                                        );
+                                        continue;
                                     }
-                                }
+                                },
                                 None => continue,
                             };
                         }
@@ -369,6 +364,23 @@ impl Wallpaper {
             l.needs_redraw = true;
         }
     }
+}
+
+fn decode(mut reader: ImageReader<BufReader<fs::File>>) -> ImageResult<DynamicImage> {
+    let mut limits = Limits::default();
+    limits.max_alloc = Some(1024 * 1024 * 1024);
+    reader.limits(limits.clone());
+
+    let mut decoder = reader.into_decoder()?;
+    let orientation = decoder.orientation()?;
+
+    limits.reserve(decoder.total_bytes())?;
+    decoder.set_limits(limits)?;
+
+    let mut image = DynamicImage::from_decoder(decoder)?;
+    image.apply_orientation(orientation);
+
+    Ok(image)
 }
 
 fn current_image(output: &str) -> Option<Source> {


### PR DESCRIPTION
Photos taken in portrait are drawn rotated. Cameras store the pixels laid out
landscape and record the rotation in the Exif metadata, and `ImageReader::decode`
ignores it. It is also why the same photo looks right in an image viewer but
rotated in the wallpaper and in the cosmic-settings preview.

Decoding through `into_decoder` gives access to the orientation the decoder
reports, so it can be applied to the decoded image. `into_decoder` does not
check the allocation limit against the size of the decoded image the way
`decode` does, so that check is kept explicitly.

Fixes #135

Tested with the 8 Exif orientation values, with images that carry no Exif
metadata (unchanged), and with the wallpapers in /usr/share/backgrounds, which
decode byte for byte identically.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
